### PR TITLE
Rakesh | BAH-1142 | BUG FIX: Ambiguous error message when CSV upload fails

### DIFF
--- a/bahmni-migrator/src/main/java/org/bahmni/csv/Migrator.java
+++ b/bahmni-migrator/src/main/java/org/bahmni/csv/Migrator.java
@@ -42,7 +42,7 @@ public class Migrator<T extends CSVEntity> {
             throw e;
         } catch (Exception e) {
             logger.error(getStackTrace(e));
-            if((e.toString().startsWith("java.lang"))){
+            if( e.toString().startsWith("java.lang") && allStages.getStages() != null && allStages.getStages().size()>=0){
                 int failedRowNumber = allStages.getStages().get(0).getFailedRowNumber();
                 throw new MigrationException("One or more column values missing or incorrect in row number " + failedRowNumber);
             }else {

--- a/bahmni-migrator/src/main/java/org/bahmni/csv/Migrator.java
+++ b/bahmni-migrator/src/main/java/org/bahmni/csv/Migrator.java
@@ -42,7 +42,12 @@ public class Migrator<T extends CSVEntity> {
             throw e;
         } catch (Exception e) {
             logger.error(getStackTrace(e));
-            throw new MigrationException(getStackTrace(e), e);
+            if((e.toString().startsWith("java.lang"))){
+                int failedRowNumber = allStages.getStages().get(0).getFailedRowNumber();
+                throw new MigrationException("One or more column values missing or incorrect in row number " + failedRowNumber);
+            }else {
+                throw new MigrationException(getStackTrace(e), e);
+            }
         }
         return stageResult;
     }

--- a/bahmni-migrator/src/main/java/org/bahmni/csv/Stages.java
+++ b/bahmni-migrator/src/main/java/org/bahmni/csv/Stages.java
@@ -28,4 +28,8 @@ class Stages<T extends CSVEntity>  {
         }
 
     }
+
+    public List<Stage<T>> getStages() {
+        return stages;
+    }
 }


### PR DESCRIPTION
## Description 
Some of the error messages that we get on CSV upload failure are technical in nature and cannot be understood by everyone or do not even point to a field that is causing the failure.

This is in case when there is a Fatal error while uploading.

Example:

java.lang.IndexOutOfBoundsException: toIndex = 31 this error is not meaningful to an end user. Instead a meaningful message stating that columns values are missing, in this case would be helpful

By resolving this every time the CSV fails upload, user will get a valid error message cause of failure and the columns/concepts that cause the issue.

## Fix

Instead of technical error, now a more generic error pointing to the row number will be displayed