### PR TITLE
BAH-1186 | [ Priya, Sameera ] |To Fix dependabot vulnerability alerts 

### DIFF
--- a/bahmni-migrator/pom.xml
+++ b/bahmni-migrator/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/file-uploader/pom.xml
+++ b/file-uploader/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/font-transformer/pom.xml
+++ b/font-transformer/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/form2-utils/pom.xml
+++ b/form2-utils/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.8.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/form2-utils/pom.xml
+++ b/form2-utils/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.hamcrest</groupId>

--- a/openmrs-connector/pom.xml
+++ b/openmrs-connector/pom.xml
@@ -19,8 +19,8 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.9</version>
+            <artifactId>jackson-mapper-lgpl</artifactId>
+            <version>1.9.13</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>

--- a/visit-squasher/pom.xml
+++ b/visit-squasher/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.6</version>
+            <version>8.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.bahmni.module</groupId>

--- a/web-clients/pom.xml
+++ b/web-clients/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.8.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/web-clients/pom.xml
+++ b/web-clients/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.4</version>
+            <version>2.9.10.7</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The following changes were made to fix the dependabot vulnerability alerts.

updated junit [ 4.8.2 to 4.13.1 ]
updated jackson-databind [ 2.9.10.4 to 2.9.10.4 ]
updated mysql-connector-java [ 5.1.6 to 8.0.16 ]
changed jackson-mapper-asl [1.9.9] to jackson-mapper-lgpl [1.9.13]
updated commons-io [ 2.4 to 2.8.0 ]