### PR TITLE
BAH-1186-new|Priya,Sameera|To remove Dependabot Alerts

### DIFF
--- a/form2-utils/pom.xml
+++ b/form2-utils/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.8.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/web-clients/pom.xml
+++ b/web-clients/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.8.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The following changes were made to fix the dependabot vulnerability alerts.

updated junit [ 4.8.2 to 4.13.1 ]
updated jackson-databind [ 2.9.10.4 to 2.9.10.4 ]
updated mysql-connector-java [ 5.1.6 to 8.0.16 ]
changed jackson-mapper-asl [1.9.9] to jackson-mapper-lgpl [1.9.13]
updated commons-io [ 2.4 to 2.8.0 ]