### PR TITLE
BAH-3525 | Fix. SQL query to handle Zero date value prohibited error

### DIFF
--- a/file-uploader/src/main/java/org/bahmni/fileimport/dao/ImportStatusDao.java
+++ b/file-uploader/src/main/java/org/bahmni/fileimport/dao/ImportStatusDao.java
@@ -16,6 +16,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class ImportStatusDao {
     private static final String IN_PROGRESS = "IN_PROGRESS";
@@ -91,13 +92,14 @@ public class ImportStatusDao {
         saveFatalError(csvFile, type, getStackTrace(exception));
     }
 
-    public List<ImportStatus> getImportStatusFromDate(Date fromDate) throws SQLException {
+    public List<ImportStatus> getImportStatusFromDate(Date fromDate) throws SQLException, InterruptedException {
         Connection connection = jdbcConnectionProvider.getConnection();
         PreparedStatement statement = null;
         List<ImportStatus> importStatuses = new ArrayList<>();
         try {
-            statement = connection.prepareStatement("select id, original_file_name, saved_file_name, error_file_name, type, status, successful_records, failed_records, stage_name, uploaded_by, start_time, end_time, stack_trace from import_status where start_time >= ? order by start_time desc");
+            statement = connection.prepareStatement("select id, original_file_name, saved_file_name, error_file_name, type, status, successful_records, failed_records, stage_name, uploaded_by, start_time, end_time, stack_trace from import_status where start_time >= ? AND start_time IS NOT NULL order by start_time desc");
             statement.setDate(1, new java.sql.Date(fromDate.getTime()));
+            TimeUnit.MILLISECONDS.sleep(500);
             ResultSet resultSet = statement.executeQuery();
             while (resultSet.next()) {
                 importStatuses.add(new ImportStatus(resultSet.getString(1), resultSet.getString(2), resultSet.getString(3),


### PR DESCRIPTION
JIRA -> [BAH-3525](https://bahmni.atlassian.net/browse/BAH-3525)

This PR addresses the "Zero date value prohibited" error by implementing the following changes:
1. Filtering out `null` values for `start_time`: The query now excludes null datetime values from the result set, resolving the error.
2. Introducing a 500-millisecond delay: Added a delay of 500 milliseconds in code execution to ensure successful completion of the upload process.